### PR TITLE
Initial OAuth2 implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM backend-comm-mongo
+MAINTAINER Pål Karlsrud <paal@128.no>
+
+ENV BASE_DIR "/var/publishing-templates"
+ENV GOPATH "/root/.go"
+ENV GOBIN ${GOPATH}/bin
+ENV GIN_MODE "release"
+
+RUN git clone https://github.com/microserv/publishing-templates ${BASE_DIR}
+RUN apk add --update curl go bzr
+
+RUN cp ${BASE_DIR}/publishing-templates.ini /etc/supervisor.d/
+RUN curl -o /etc/supervisor.d/mongodb.ini https://128.no/f/mongodb.ini
+
+WORKDIR ${BASE_DIR}
+RUN go get -v
+RUN go build
+
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ WORKDIR ${BASE_DIR}
 RUN go get -v
 RUN go build
 
+# For some reason /run is not a dir in this image, so we need to create it.
+RUN rm /run && mkdir -p /run
+
 EXPOSE 80

--- a/auth.go
+++ b/auth.go
@@ -50,7 +50,7 @@ func ValidateUserToken(authorization_code string) (bool, string) {
 	application_information := OAuth2Provider{
 		auth_endpoint: "http://127.0.0.1:8000/oauth2/token/",
 		redirect_uri:  "http://127.0.0.1:8080/oauth2/callback",
-		client_id:     "49UCr6bEdK4cOIWWCESP3mviXD0onxJpvwoSg9Ao",
+		client_id:     "",
 	}
 
 	grant_type := "authorization_code"

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,79 @@
+package main
+
+import "encoding/json"
+import "fmt"
+import "io/ioutil"
+import "net/http"
+import "net/url"
+import "strings"
+
+
+type OAuth2Provider struct {
+    auth_endpoint, client_id, client_secret, redirect_uri string
+}
+
+type OAuth2Credentials struct {
+    Access_token, Token_type, Scope string
+    Expires_in int
+}
+
+func tokenHasScope(token OAuth2Credentials, required_scope string) bool {
+    return strings.Index(token.Scope, required_scope) != -1
+}
+
+func ValidateUserToken(authorization_code string) (bool, string) {
+    
+    if authorization_code == "" {
+        return false, "No authorization_code provided"
+    }
+        
+    application_information := OAuth2Provider{
+        auth_endpoint: "http://127.0.0.1:8000/oauth2/token/",
+        redirect_uri: "http://127.0.0.1:8080/oauth2/callback",
+        client_id: "",
+    }
+    
+    grant_type := "authorization_code"
+    
+    stuff := url.Values{
+        "client_id": {application_information.client_id}, 
+        "grant_type": {grant_type}, 
+        "code": {authorization_code},
+        "redirect_uri": {application_information.redirect_uri},
+    }
+
+    // Getting a token
+    resp, err := http.PostForm(application_information.auth_endpoint,
+        stuff,
+    )
+    
+    if err != nil {
+        // @ToDo: Log instead of print
+        fmt.Printf("err: %v\n", err)
+    } else {
+        // Connection was OK, let's process it
+        defer resp.Body.Close()
+        body, body_err := ioutil.ReadAll(resp.Body)
+        
+        if body_err != nil || strings.Index(string(body), "error") != -1 {
+            // @ToDo: Log instead of print
+            fmt.Printf("body_err: %v\n", body_err)
+            fmt.Printf("body: %v\n", string(body))
+            return false, string(body)
+        } else {
+            var tokeninfo OAuth2Credentials
+            json_err := json.Unmarshal([]uint8(body), &tokeninfo)
+            
+            if json_err != nil {
+                // @ToDo: Log instead of print
+                fmt.Printf("Json unmarshal err: %v\n", json_err)
+                return false, fmt.Sprintf("JSON parse error: %v", json_err)
+            } else {
+                // Parsing is OK, verify token scope and return
+                has_scope := tokenHasScope(tokeninfo, "read")
+                return has_scope, ""
+            }
+        }
+    }
+    return false, "Something went wrong"
+}

--- a/auth.go
+++ b/auth.go
@@ -2,78 +2,153 @@ package main
 
 import "encoding/json"
 import "fmt"
+import "github.com/gin-gonic/gin"
 import "io/ioutil"
 import "net/http"
 import "net/url"
 import "strings"
 
-
 type OAuth2Provider struct {
-    auth_endpoint, client_id, client_secret, redirect_uri string
+	auth_endpoint, client_id, client_secret, redirect_uri string
 }
 
 type OAuth2Credentials struct {
-    Access_token, Token_type, Scope string
-    Expires_in int
+	Access_token, Token_type, Scope string
+	Expires_in                      int
 }
 
 func tokenHasScope(token OAuth2Credentials, required_scope string) bool {
-    return strings.Index(token.Scope, required_scope) != -1
+	return strings.Index(token.Scope, required_scope) != -1
+}
+
+var valid_tokens []OAuth2Credentials
+
+func printValidTokens() {
+	fmt.Println("Valid tokens:")
+
+	for key, val := range valid_tokens {
+		fmt.Printf("%v: %v\n", key, val)
+	}
+}
+
+func IsTokenValid(token, scope string) bool {
+	for _, val := range valid_tokens {
+		if val.Access_token == token {
+			return tokenHasScope(val, scope)
+		}
+	}
+	return false
 }
 
 func ValidateUserToken(authorization_code string) (bool, string) {
-    
-    if authorization_code == "" {
-        return false, "No authorization_code provided"
-    }
-        
-    application_information := OAuth2Provider{
-        auth_endpoint: "http://127.0.0.1:8000/oauth2/token/",
-        redirect_uri: "http://127.0.0.1:8080/oauth2/callback",
-        client_id: "",
-    }
-    
-    grant_type := "authorization_code"
-    
-    stuff := url.Values{
-        "client_id": {application_information.client_id}, 
-        "grant_type": {grant_type}, 
-        "code": {authorization_code},
-        "redirect_uri": {application_information.redirect_uri},
-    }
+	// Intentionally kept for easier debugging
+	// printValidTokens()
+	if authorization_code == "" {
+		return false, "Missing authorization_code"
+	}
 
-    // Getting a token
-    resp, err := http.PostForm(application_information.auth_endpoint,
-        stuff,
-    )
-    
-    if err != nil {
-        // @ToDo: Log instead of print
-        fmt.Printf("err: %v\n", err)
-    } else {
-        // Connection was OK, let's process it
-        defer resp.Body.Close()
-        body, body_err := ioutil.ReadAll(resp.Body)
-        
-        if body_err != nil || strings.Index(string(body), "error") != -1 {
-            // @ToDo: Log instead of print
-            fmt.Printf("body_err: %v\n", body_err)
-            fmt.Printf("body: %v\n", string(body))
-            return false, string(body)
-        } else {
-            var tokeninfo OAuth2Credentials
-            json_err := json.Unmarshal([]uint8(body), &tokeninfo)
-            
-            if json_err != nil {
-                // @ToDo: Log instead of print
-                fmt.Printf("Json unmarshal err: %v\n", json_err)
-                return false, fmt.Sprintf("JSON parse error: %v", json_err)
-            } else {
-                // Parsing is OK, verify token scope and return
-                has_scope := tokenHasScope(tokeninfo, "read")
-                return has_scope, ""
-            }
-        }
-    }
-    return false, "Something went wrong"
+	application_information := OAuth2Provider{
+		auth_endpoint: "http://127.0.0.1:8000/oauth2/token/",
+		redirect_uri:  "http://127.0.0.1:8080/oauth2/callback",
+		client_id:     "49UCr6bEdK4cOIWWCESP3mviXD0onxJpvwoSg9Ao",
+	}
+
+	grant_type := "authorization_code"
+
+	stuff := url.Values{
+		"client_id":    {application_information.client_id},
+		"grant_type":   {grant_type},
+		"code":         {authorization_code},
+		"redirect_uri": {application_information.redirect_uri},
+	}
+
+	// Getting a token
+	resp, err := http.PostForm(application_information.auth_endpoint,
+		stuff,
+	)
+
+	if err != nil {
+		// @ToDo: Log instead of print
+		fmt.Printf("err: %v\n", err)
+		return false, fmt.Sprintf("Error: %v", err)
+	} else {
+		// Connection was OK, let's process it
+		defer resp.Body.Close()
+		body, body_err := ioutil.ReadAll(resp.Body)
+
+		if body_err != nil || strings.Index(string(body), "error") != -1 {
+			// @ToDo: Log instead of print
+			fmt.Printf("body_err: %v\n", body_err)
+			fmt.Printf("body: %v\n", string(body))
+			return false, fmt.Sprintf("Error: %v\n%v", body_err, string(body))
+		} else {
+			var tokeninfo OAuth2Credentials
+			json_err := json.Unmarshal([]uint8(body), &tokeninfo)
+			valid_tokens = append(valid_tokens, tokeninfo)
+
+			// Intentionally kept for easier debug
+			// fmt.Printf("body: %v\n", string(body))
+
+			if json_err != nil {
+				// @ToDo: Log instead of print
+				fmt.Printf("Json unmarshal err: %v\n", json_err)
+				return false, fmt.Sprintf("JSON Error: %v", json_err)
+			} else {
+				// Parsing is OK, verify token scope and return
+				return true, ""
+			}
+		}
+	}
+}
+
+func getTokenFromHeader(r *http.Request) string {
+	authorization_header := r.Header.Get("Authorization")
+	if authorization_header == "" {
+		return ""
+	}
+
+	header_split := strings.Split(authorization_header, " ")
+
+	if len(header_split) != 2 {
+		fmt.Println("Malformed Authorization header")
+		return ""
+	}
+
+	token := header_split[1] // Header is 2nd item in Authorization header split by " "
+	return token
+}
+
+func getToken(c *gin.Context) string {
+	token_from_header := getTokenFromHeader(c.Request)
+	if token_from_header != "" {
+		return token_from_header
+	}
+
+	token_from_urlparams := c.DefaultQuery("token", "")
+	if token_from_urlparams != "" {
+		return token_from_urlparams
+	}
+
+	return ""
+}
+
+func ValidateRequest(scope string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token := getToken(c)
+
+		if token == "" {
+			c.AbortWithStatus(401)
+			c.JSON(401, generateJSONErr(401, "Missing authentication credentials"))
+			return
+		}
+
+		access_granted := IsTokenValid(token, scope)
+
+		if !access_granted {
+			c.AbortWithStatus(403)
+			c.JSON(403, generateJSONErr(403, "Permission denied"))
+			return
+		}
+		c.Header("WWW-Authenticate", "No authorization_code provided")
+	}
 }

--- a/db.go
+++ b/db.go
@@ -65,6 +65,17 @@ func queryCollection(searchParams map[string]string) []Template {
 	return results
 }
 
+func getAllTemplates() []Template {
+	sessionCopy := mongoSession.Copy()
+	defer sessionCopy.Close()
+
+	collection := sessionCopy.DB(DB_NAME).C(DB_COLL)
+
+	var results []Template
+	collection.Find(nil).All(&results)
+	return results
+}
+
 // Get all templates matching this name.
 func getTemplatesByName(name string) []Template {
 	var searchParams = make(map[string]string)

--- a/handlers.go
+++ b/handlers.go
@@ -77,3 +77,30 @@ func DeleteTemplate(c *gin.Context) {
 		c.JSON(204, "The template was successfully deleted.")
 	}
 }
+
+func OAuth2Callback(c *gin.Context) {
+	response := make(map[string]string)
+	code := c.DefaultQuery("code", "")
+	next := c.DefaultQuery("next", "")
+
+	response["code"] = code
+	response["next"] = next
+
+	if code != "" {
+		valid, err := ValidateUserToken(code)
+		if err != "" {
+			fmt.Printf("Authentication failed: %v\n", err)
+		} else {
+			if valid {
+				// Debug
+				// fmt.Println("Authentication succeeded")
+			} else {
+				fmt.Println("Token does not carry correct scope for this operation.")
+			}
+		}
+		c.JSON(200, response)
+		// Redirect to "next" param, as that's where the user wants to go
+	} else {
+		c.JSON(400, generateJSONErr(400, "Missing code"))
+	}
+}

--- a/handlers.go
+++ b/handlers.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"github.com/gin-gonic/gin"
-	"strconv"
 )
 
 func GetTemplate(c *gin.Context) {
@@ -16,21 +15,7 @@ func GetTemplate(c *gin.Context) {
 }
 
 func GetAllTemplates(c *gin.Context) {
-	var _num = c.DefaultQuery("limit", "10")
-
-	num, err := strconv.Atoi(_num)
-	if err != nil {
-		str := fmt.Sprintf("Invalid value for \"limit\", should be int but was %T (%v).", _num, _num)
-		c.JSON(400, generateJSONErr(400, str))
-		c.Abort()
-		return
-	}
-
-	var response [10]map[string]string
-
-	response = generateDummyTemplates(num)
-
-	c.JSON(200, response)
+	c.JSON(200, getAllTemplates())
 }
 
 func InsertTemplate(c *gin.Context) {

--- a/publishing-templates.ini
+++ b/publishing-templates.ini
@@ -1,0 +1,6 @@
+[program:publishing-templates]
+command=/var/publishing-templates/publishing-templates
+directory=/var/publishing-templates
+autostart=true
+autorestart=true
+startretries=3

--- a/server.go
+++ b/server.go
@@ -13,7 +13,7 @@ func main() {
 
 	connectToDb()
 
-	engine.Run(":8080")
+	engine.Run(":80")
 }
 
 func AddRoutes(version string, engine *gin.Engine) {

--- a/server.go
+++ b/server.go
@@ -17,14 +17,22 @@ func main() {
 }
 
 func AddRoutes(version string, engine *gin.Engine) {
-	api_group := engine.Group(fmt.Sprintf("api/v%s", version))
+	oauth2_routes := engine.Group("oauth2")
 	{
-		api_group.GET("/template/", GetAllTemplates)
-		api_group.GET("/template/:template_name", GetTemplate)
+		oauth2_routes.GET("/callback", OAuth2Callback)
+	}
 
-		api_group.POST("/template/", InsertTemplate)
-		api_group.PUT("/template/", UpdateTemplate)
+	public_routes := engine.Group(fmt.Sprintf("api/v%s", version))
+	{
+		public_routes.GET("/template/", GetAllTemplates)
+		public_routes.GET("/template/:template_name", GetTemplate)
+	}
 
-		api_group.DELETE("/template/:template_name", DeleteTemplate)
+	template_restricted := engine.Group(fmt.Sprintf("api/v%s", version))
+	template_restricted.Use(ValidateRequest("write"))
+	{
+		template_restricted.POST("/template/", InsertTemplate)
+		template_restricted.PUT("/template/:template_name", GetTemplate)
+		template_restricted.DELETE("/template/:template_name", DeleteTemplate)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -16,6 +16,8 @@ func main() {
 	engine.Run(":80")
 }
 
+const enable_access_control = false
+
 func AddRoutes(version string, engine *gin.Engine) {
 	oauth2_routes := engine.Group("oauth2")
 	{
@@ -29,7 +31,9 @@ func AddRoutes(version string, engine *gin.Engine) {
 	}
 
 	template_restricted := engine.Group(fmt.Sprintf("api/v%s", version))
-	template_restricted.Use(ValidateRequest("write"))
+	if enable_access_control {
+        template_restricted.Use(ValidateRequest("write"))
+    }
 	{
 		template_restricted.POST("/template/", InsertTemplate)
 		template_restricted.PUT("/template/:template_name", GetTemplate)


### PR DESCRIPTION
Initial implementation of OAuth2 for Publishing:Templates.

For now, to gain access to the restricted functions, follow this flow (is being improved) [only required if "enable_access_control" is set to true]:
- Run [microauth](https://github.com/microserv/microauth)
- Create an application (client) for Publishing:Templates, Public with Authorization Code.
- Set the Client ID for the application in Publishing:Templates (`auth.go`)
- Run the Publishing:Templates server
- Authorize against Publishing:Templates (go to `http://microauth/oauth2/authorize?client_id=CLIENT_ID&response_type=code&scope=write`)
  - where CLIENT_ID is the client id from above. _Scope will be changed later on to better suit multiple apps._
- Be redirected to Publishing:Templates. Publishing:Templates now has your access token registered.
- Do an unsafe HTTP request against Publishing:Templates, e.g. a HTTP POST towards `http://publishingtemplates/api/v1/templates` with `Authorization` header set (e.g. `Authorization: Bearer kekSnek4884lalalole`
### **!!!**

 Any tokens will be **forgotten** upon restart of Publishing:Templates.

---

PS: The only OAuth2 client framework for Go is weird, so I had to simplify the functionality and code it myself.
